### PR TITLE
Parse url encoded values from slack

### DIFF
--- a/serverless/todos/create.payload
+++ b/serverless/todos/create.payload
@@ -1,0 +1,13 @@
+token=gIkuvaNzQIHg97ATvDxqgjtO
+&team_id=T0001
+&team_domain=example
+&enterprise_id=E0001
+&enterprise_name=Globular%20Construct%20Inc
+&channel_id=C2147483705
+&channel_name=test
+&user_id=U2147483697
+&user_name=Steve
+&command=/toil-add
+&text=MyFirstToil
+&response_url=https://hooks.slack.com/commands/1234/5678
+&trigger_id=13345224609.738474920.8088930838d88f008e0

--- a/serverless/todos/create.py
+++ b/serverless/todos/create.py
@@ -3,6 +3,8 @@ import logging
 import os
 import time
 import uuid
+import ast
+from urllib import parse
 from datetime import datetime
 
 import boto3
@@ -10,12 +12,17 @@ dynamodb = boto3.resource('dynamodb')
 
 
 def create(event, context):
-    data = json.loads(event['body'])
     print("Event obj: {}".format(json.dumps(event)))
-    print("Data obj: {}".format(json.dumps(data)))
-    if 'text' not in data:
-        logging.error("Validation Failed")
-        raise Exception("Couldn't create the todo item.")
+
+    domainName = json.dumps(event["requestContext"]["domainName"])
+    path = json.dumps(event["requestContext"]["path"])
+    queryStringParams = json.dumps(event["body"])
+    url = "https://{}{}?{}".format(ast.literal_eval(domainName), ast.literal_eval(path), ast.literal_eval(queryStringParams))
+    print(url)
+    parsed_url = parse.urlsplit(url)
+    print(parsed_url)
+    qsp_dict = dict(parse.parse_qsl(parse.urlsplit(url).query))
+    print(json.dumps(qsp_dict))
 
     timestamp = str(datetime.utcnow().isoformat())
 
@@ -23,7 +30,7 @@ def create(event, context):
 
     item = {
         'id': str(uuid.uuid1()),
-        'text': data['text'],
+        'text': qsp_dict['text'],
         'checked': False,
         'createdAt': timestamp,
         'updatedAt': timestamp,

--- a/serverless/todos/x-www-form-urlencoded.template
+++ b/serverless/todos/x-www-form-urlencoded.template
@@ -1,0 +1,51 @@
+## convert HTML POST data or HTTP GET query string to JSON
+ 
+## get the raw post data from the AWS built-in variable and give it a nicer name
+#if ($context.httpMethod == "POST")
+ #set($rawAPIData = $input.path('$'))
+#elseif ($context.httpMethod == "GET")
+ #set($rawAPIData = $input.params().querystring)
+ #set($rawAPIData = $rawAPIData.toString())
+ #set($rawAPIDataLength = $rawAPIData.length() - 1)
+ #set($rawAPIData = $rawAPIData.substring(1, $rawAPIDataLength))
+ #set($rawAPIData = $rawAPIData.replace(", ", "&"))
+#else
+ #set($rawAPIData = "")
+#end
+ 
+## first we get the number of "&" in the string, this tells us if there is more than one key value pair
+#set($countAmpersands = $rawAPIData.length() - $rawAPIData.replace("&", "").length())
+ 
+## if there are no "&" at all then we have only one key value pair.
+## we append an ampersand to the string so that we can tokenise it the same way as multiple kv pairs.
+## the "empty" kv pair to the right of the ampersand will be ignored anyway.
+#if ($countAmpersands == 0)
+ #set($rawPostData = $rawAPIData + "&")
+#end
+ 
+## now we tokenise using the ampersand(s)
+#set($tokenisedAmpersand = $rawAPIData.split("&"))
+ 
+## we set up a variable to hold the valid key value pairs
+#set($tokenisedEquals = [])
+ 
+## now we set up a loop to find the valid key value pairs, which must contain only one "="
+#foreach( $kvPair in $tokenisedAmpersand )
+ #set($countEquals = $kvPair.length() - $kvPair.replace("=", "").length())
+ #if ($countEquals == 1)
+  #set($kvTokenised = $kvPair.split("="))
+  #if ($kvTokenised[0].length() > 0)
+   ## we found a valid key value pair. add it to the list.
+   #set($devNull = $tokenisedEquals.add($kvPair))
+  #end
+ #end
+#end
+ 
+## next we set up our loop inside the output structure "{" and "}"
+{
+#foreach( $kvPair in $tokenisedEquals )
+  ## finally we output the JSON for this pair and append a comma if this isn't the last pair
+  #set($kvTokenised = $kvPair.split("="))
+ "$util.urlDecode($kvTokenised[0])" : #if($kvTokenised[1].length() > 0)"$util.urlDecode($kvTokenised[1])"#{else}""#end#if( $foreach.hasNext ),#end
+#end
+}


### PR DESCRIPTION
- Added sample payload for following curl command to test:
curl -XPOST -H "Content-Type: application/x-www-form-urlencoded" -d @todos/create.payload https://ixs16j3ull.execute-api.us-east-1.amazonaws.com/jp/todos
- Added mapping template as well in case we want to move to Lambda type
function+apigw instead of lambda_proxy type.
https://serverless.com/framework/docs/providers/aws/events/apigateway#custom-request-templates
- Parse the event object to construct full url string including
urlencoded qsps, then use urllib to parse and ultimately turn the qsps
into a dictionary object.
- Validated that the create function runs with arguments and creates new
item in dynamodb.